### PR TITLE
Use display-buffer

### DIFF
--- a/anything-myrurema.el
+++ b/anything-myrurema.el
@@ -65,7 +65,7 @@
         (goto-char (point-min))
         (delete-region (point) (save-excursion (end-of-line) (point)))
         (delete-blank-lines))
-      (switch-to-buffer buf)))
+      (display-buffer buf)))
 
 (defun anything-myrurema-rurema-search (candidate)
     (browse-url (format "http://rurema.clear-code.com/query:%s/" (url-hexify-string candidate))))


### PR DESCRIPTION
`switch-to-buffer` uses current buffer, but `display-buffer` allow the user to customize the behavior.

Especially, `popwin` only works for `display-buffer`.
Some want to show Help in `popwin`.
